### PR TITLE
feat(home-assistant): bump base image to v2024.9.1

### DIFF
--- a/roles/homeassistant/vars/main.yml
+++ b/roles/homeassistant/vars/main.yml
@@ -1,7 +1,7 @@
 ---
 # https://hub.docker.com/r/linuxserver/homeassistant/tags
 homeassistant_base_image: "lscr.io/linuxserver/homeassistant"
-homeassistant_base_image_tag: "2024.8.1"
+homeassistant_base_image_tag: "2024.9.1"
 
 homeassistant_avahi_image_name: "homeassistant-avahi"
 homeassistant_avahi_image_tag: "{{ homeassistant_base_image_tag }}-avahi"


### PR DESCRIPTION
https://github.com/home-assistant/core/releases/tag/2024.9.1
